### PR TITLE
fix: sub tenant in docs where needed

### DIFF
--- a/api-reference/api_schema/delete_memory.yaml
+++ b/api-reference/api_schema/delete_memory.yaml
@@ -39,6 +39,10 @@
                 type: string
                 description: Primary organizational identifier (e.g., enterprise client, company) for multi-tenant data isolation
                 example: tenant_456
+              sub_tenant_id:
+                type: string
+                description: Sub-tenant identifier
+                example: subtenant_123
               source_ids:
                 type: array
                 items:

--- a/api-reference/api_schema/list-sources_by_id.yaml
+++ b/api-reference/api_schema/list-sources_by_id.yaml
@@ -39,6 +39,10 @@
                 type: string
                 description: Primary organizational identifier (e.g., enterprise client, company) for multi-tenant data isolation
                 example: tenant_456
+              sub_tenant_id:
+                type: string
+                description: Sub-tenant identifier
+                example: subtenant_123
               source_ids:
                 type: array
                 items:

--- a/api-reference/endpoint/delete-memory.mdx
+++ b/api-reference/endpoint/delete-memory.mdx
@@ -13,6 +13,7 @@ curl --location 'https://api.usecortex.ai/upload/delete_source' \
   --header 'Content-Type: application/json' \
   --data '{
     "tenant_id": "{TENANT_ID}",
+    "sub_tenant_id": "{SUB_TENANT_ID},
     "source_ids": ["{SOURCE_ID1}", "{SOURCE_ID2}"]
   }'
 ```

--- a/api-reference/endpoint/list-sources-by-id.mdx
+++ b/api-reference/endpoint/list-sources-by-id.mdx
@@ -12,6 +12,7 @@ curl --location 'https://api.usecortex.ai/list/sources_by_id' \
   --header 'Content-Type: application/json' \
   --data '{
     "tenant_id": "{TENANT_ID}",
+    "sub_tenant_id": "{SUB_TENANT_ID},
     "source_ids": ["{SOURCE_ID1}", "{SOURCE_ID2}"]
   }'
 ```

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1907,6 +1907,11 @@
                       "description": "Primary organizational identifier (e.g., enterprise client, company) for multi-tenant data isolation",
                       "example": "tenant_456"
                     },
+                    "sub_tenant_id": {
+                      "type": "string",
+                      "description": "Sub tenant identifier",
+                      "example": "subtenant_123"
+                    },
                     "source_ids": {
                       "type": "array",
                       "items": {
@@ -1989,6 +1994,11 @@
                       "type": "string",
                       "description": "Primary organizational identifier (e.g., enterprise client, company) for multi-tenant data isolation",
                       "example": "tenant_456"
+                    },
+                    "sub_tenant_id": {
+                      "type": "string",
+                      "description": "Sub tenant identifier",
+                      "example": "subtenant_123"
                     },
                     "source_ids": {
                       "type": "array",


### PR DESCRIPTION
Adds `sub_tenant_id` support to the delete-memory and list-sources-by-id endpoints. This aligns our APIs with the finer-grained multi-tenant model already used across Cortex.

### Changes  
- Extended request schemas (`delete_memory.yaml`, `list-sources_by_id.yaml`) with an optional `sub_tenant_id` string for sub-tenant isolation.  
- Updated associated MDX examples so cURL snippets now show the new field.  
- No functional code paths changed—this is strictly an API-contract/documentation update to unblock downstream clients.

### Testing  
*No tests included in this PR.*