### PR TITLE
Feat: includes py script that can automatically convert generated openapi spec to what we need

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -5774,17 +5774,6 @@
             ],
             "title": "Document Metadata",
             "description": "JSON string containing document-specific metadata (e.g., title, author, file_id). If file_id is not provided, the system will generate an ID automatically.\n\nExample: > \"{\"title\":\"Q1 Report.pdf\",\"author\":\"Alice Smith\",\"file_id\":\"custom_file_123\"}\"\n\n\n"
-          },
-          "relations": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Relations"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Optional JSON string containing relations as key-value pairs"
           }
         },
         "type": "object",

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -658,18 +658,6 @@
             "description": "Unique identifier for the tenant/organization"
           },
           {
-            "name": "query",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Search query to find relevant user memories",
-              "title": "Query",
-              "default": "Which mode does user prefer"
-            },
-            "description": "Search query to find relevant user memories"
-          },
-          {
             "name": "sub_tenant_id",
             "in": "query",
             "required": false,
@@ -823,30 +811,6 @@
             "description": "Unique identifier for the tenant/organization"
           },
           {
-            "name": "user_query",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Your query or context for AI memory generation",
-              "title": "User Query",
-              "default": "Which mode does user prefer"
-            },
-            "description": "Your query or context for AI memory generation"
-          },
-          {
-            "name": "user_name",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Your name to personalize the generated memories",
-              "title": "User Name",
-              "default": "John Doe"
-            },
-            "description": "Your name to personalize the generated memories"
-          },
-          {
             "name": "sub_tenant_id",
             "in": "query",
             "required": false,
@@ -984,18 +948,6 @@
               "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
-          },
-          {
-            "name": "user_memory",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "The memory content to store for future reference",
-              "title": "User Memory",
-              "default": "user_memory_1234"
-            },
-            "description": "The memory content to store for future reference"
           },
           {
             "name": "sub_tenant_id",
@@ -1245,8 +1197,7 @@
               "title": "Tenant Id",
               "default": "tenant_1234"
             },
-            "description": "Unique identifier for the tenant/organization",
-            "example": "tenant_abcdefg"
+            "description": "Unique identifier for the tenant/organization"
           },
           {
             "name": "sub_tenant_id",
@@ -1258,8 +1209,7 @@
               "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
-            "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-            "example": "sub_tenant_abcdef"
+            "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
           }
         ],
         "requestBody": {
@@ -1523,8 +1473,7 @@
               "title": "Tenant Id",
               "default": "tenant_1234"
             },
-            "description": "Unique identifier for the tenant/organization",
-            "example": "1234"
+            "description": "Unique identifier for the tenant/organization"
           },
           {
             "name": "sub_tenant_id",
@@ -1536,8 +1485,7 @@
               "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
-            "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-            "example": "5678"
+            "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
           }
         ],
         "requestBody": {
@@ -1675,8 +1623,7 @@
               "title": "Tenant Id",
               "default": "tenant_1234"
             },
-            "description": "Unique identifier for the tenant/organization",
-            "example": "1234"
+            "description": "Unique identifier for the tenant/organization"
           },
           {
             "name": "sub_tenant_id",
@@ -1688,8 +1635,7 @@
               "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
-            "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-            "example": "5678"
+            "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
           }
         ],
         "requestBody": {
@@ -2849,6 +2795,15 @@
             "description": "Optional custom file ID for the scraped content. If not provided, a unique ID will be generated"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_scrape_webpage_upload_scrape_webpage_post"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -3001,6 +2956,15 @@
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_update_scrape_job_upload_update_webpage_patch"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -3090,119 +3054,6 @@
         ]
       }
     },
-    "/upload/delete_memory": {
-      "delete": {
-        "tags": [
-          "upload"
-        ],
-        "summary": "Delete Memory",
-        "description": "Remove documents and content from your knowledge base.\n\nThis endpoint permanently deletes the specified sources from your knowledge base. Once deleted, the content will no longer be available for search or retrieval.\n\nUse this carefully as the action cannot be undone. The system will confirm successful deletion of each source ID you specify.",
-        "operationId": "delete_memory_upload_delete_memory_delete",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DeleteMemoryRequest",
-                "description": "Request body containing the source IDs to delete and tenant information"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeleteSources"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request - Invalid input parameters",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActualErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized - Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActualErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden - Access denied",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActualErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found - Resource does not exist",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActualErrorResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity - Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActualErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActualErrorResponse"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "Service Unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActualErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "x-fern-sdk-group-name": "upload",
-        "x-fern-sdk-method-name": "delete_memory",
-        "x-fern-sdk-audience": [
-          "public"
-        ]
-      }
-    },
     "/upload/delete_source": {
       "delete": {
         "tags": [
@@ -3227,78 +3078,16 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeleteSources"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request - Invalid input parameters",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActualErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized - Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActualErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden - Access denied",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActualErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found - Resource does not exist",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActualErrorResponse"
-                }
+                "schema": {}
               }
             }
           },
           "422": {
-            "description": "Unprocessable Entity - Validation failed",
+            "description": "Validation Error",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ActualErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActualErrorResponse"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "Service Unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActualErrorResponse"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -3311,6 +3100,57 @@
         ],
         "x-fern-sdk-group-name": "upload",
         "x-fern-sdk-method-name": "delete_source",
+        "x-fern-sdk-audience": [
+          "public"
+        ]
+      }
+    },
+    "/upload/delete_memory": {
+      "delete": {
+        "tags": [
+          "upload"
+        ],
+        "summary": "Delete Memory",
+        "description": "Remove documents and content from your knowledge base.\n\nThis endpoint permanently deletes the specified sources from your knowledge base. Once deleted, the content will no longer be available for search or retrieval.\n\nUse this carefully as the action cannot be undone. The system will confirm successful deletion of each source ID you specify.",
+        "operationId": "delete_memory_upload_delete_memory_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteMemoryRequest",
+                "description": "Request body containing the source IDs to delete and tenant information"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "x-fern-sdk-group-name": "upload",
+        "x-fern-sdk-method-name": "delete_memory",
         "x-fern-sdk-audience": [
           "public"
         ]
@@ -5034,6 +4874,11 @@
         "type": "object",
         "title": "Body_create_tenant_user_create_tenant_post"
       },
+      "Body_scrape_webpage_upload_scrape_webpage_post": {
+        "properties": {},
+        "type": "object",
+        "title": "Body_scrape_webpage_upload_scrape_webpage_post"
+      },
       "Body_update_file_upload_update_document_patch": {
         "properties": {
           "file": {
@@ -5072,6 +4917,11 @@
           "file"
         ],
         "title": "Body_update_file_upload_update_document_patch"
+      },
+      "Body_update_scrape_job_upload_update_webpage_patch": {
+        "properties": {},
+        "type": "object",
+        "title": "Body_update_scrape_job_upload_update_webpage_patch"
       },
       "Body_upload_files_upload_upload_document_post": {
         "properties": {
@@ -5557,6 +5407,27 @@
         "type": "object",
         "title": "ErrorResponse"
       },
+      "ExtendedContext": {
+        "properties": {
+          "relations": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/RelatedChunk"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Relations",
+            "default": []
+          }
+        },
+        "type": "object",
+        "title": "ExtendedContext"
+      },
       "FetchContentData": {
         "properties": {
           "file_id": {
@@ -5798,6 +5669,19 @@
         ],
         "title": "GetEmbeddingsBasedOnChunkIdsRequest"
       },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
       "ListSourcesResponse": {
         "properties": {
           "sources": {
@@ -5890,6 +5774,17 @@
             ],
             "title": "Document Metadata",
             "description": "JSON string containing document-specific metadata (e.g., title, author, file_id). If file_id is not provided, the system will generate an ID automatically.\n\nExample: > \"{\"title\":\"Q1 Report.pdf\",\"author\":\"Alice Smith\",\"file_id\":\"custom_file_123\"}\"\n\n\n"
+          },
+          "relations": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Relations"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional JSON string containing relations as key-value pairs"
           }
         },
         "type": "object",
@@ -6139,6 +6034,68 @@
           "tenant_id"
         ],
         "title": "QnARequest"
+      },
+      "RelatedChunk": {
+        "properties": {
+          "source_id": {
+            "type": "string",
+            "title": "Source Id"
+          },
+          "chunk_uuid": {
+            "type": "string",
+            "title": "Chunk Uuid"
+          },
+          "chunk_content": {
+            "type": "string",
+            "title": "Chunk Content"
+          },
+          "source_title": {
+            "type": "string",
+            "title": "Source Title",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "required": [
+          "source_id",
+          "chunk_uuid",
+          "chunk_content"
+        ],
+        "title": "RelatedChunk"
+      },
+      "Relations": {
+        "properties": {
+          "cortex_source_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cortex Source Ids",
+            "description": "List of cortex source IDs to directly relate with"
+          },
+          "auto_discovery": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Auto Discovery",
+            "description": "Key value pairs to allow cortex to automatically discover relations"
+          }
+        },
+        "type": "object",
+        "title": "Relations"
       },
       "RetrieveUserMemoryRequest": {
         "properties": {
@@ -6715,6 +6672,39 @@
         ],
         "title": "UserMemory",
         "description": "Represents a user memory stored in the system."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
       }
     },
     "securitySchemes": {

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -144,7 +144,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
           },
@@ -155,7 +156,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
@@ -383,7 +384,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
           },
@@ -394,7 +396,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
@@ -510,7 +512,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
           },
@@ -521,7 +524,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier of the memory to delete",
-              "title": "Memory Id"
+              "title": "Memory Id",
+              "default": "memory_1234"
             },
             "description": "Unique identifier of the memory to delete"
           },
@@ -532,7 +536,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
@@ -648,9 +652,22 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Search query to find relevant user memories",
+              "title": "Query",
+              "default": "Which mode does user prefer"
+            },
+            "description": "Search query to find relevant user memories"
           },
           {
             "name": "sub_tenant_id",
@@ -659,7 +676,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
@@ -800,9 +817,34 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
+          },
+          {
+            "name": "user_query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Your query or context for AI memory generation",
+              "title": "User Query",
+              "default": "Which mode does user prefer"
+            },
+            "description": "Your query or context for AI memory generation"
+          },
+          {
+            "name": "user_name",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Your name to personalize the generated memories",
+              "title": "User Name",
+              "default": "John Doe"
+            },
+            "description": "Your name to personalize the generated memories"
           },
           {
             "name": "sub_tenant_id",
@@ -811,7 +853,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
@@ -938,9 +980,22 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
+          },
+          {
+            "name": "user_memory",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The memory content to store for future reference",
+              "title": "User Memory",
+              "default": "user_memory_1234"
+            },
+            "description": "The memory content to store for future reference"
           },
           {
             "name": "sub_tenant_id",
@@ -949,7 +1004,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
@@ -1187,7 +1242,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization",
             "example": "tenant_abcdefg"
@@ -1199,7 +1255,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
@@ -1326,7 +1382,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
           },
@@ -1337,7 +1394,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
@@ -1463,7 +1520,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization",
             "example": "1234"
@@ -1475,7 +1533,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
@@ -1602,7 +1660,8 @@
             "schema": {
               "type": "string",
               "description": "The source ID of the document to update",
-              "title": "Source Id"
+              "title": "Source Id",
+              "default": "CortexDoc1234"
             },
             "description": "The source ID of the document to update"
           },
@@ -1613,7 +1672,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization",
             "example": "1234"
@@ -1625,7 +1685,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
@@ -1752,7 +1812,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
           },
@@ -1763,7 +1824,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
@@ -1894,7 +1955,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
           },
@@ -1905,7 +1967,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
@@ -2031,7 +2093,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
           },
@@ -2042,7 +2105,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
@@ -2168,7 +2231,8 @@
             "schema": {
               "type": "string",
               "description": "The source ID of the document to update",
-              "title": "Source Id"
+              "title": "Source Id",
+              "default": "CortexDoc1234"
             },
             "description": "The source ID of the document to update"
           },
@@ -2179,7 +2243,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
           },
@@ -2190,7 +2255,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
@@ -2316,7 +2381,8 @@
             "schema": {
               "type": "string",
               "description": "The source ID of the document to update",
-              "title": "Source Id"
+              "title": "Source Id",
+              "default": "CortexDoc1234"
             },
             "description": "The source ID of the document to update"
           },
@@ -2327,7 +2393,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
           },
@@ -2338,7 +2405,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
@@ -2464,7 +2531,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
           },
@@ -2475,7 +2543,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
@@ -2601,7 +2669,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
           },
@@ -2612,7 +2681,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
@@ -2738,7 +2807,8 @@
             "schema": {
               "type": "string",
               "description": "The URL of the webpage to scrape and index",
-              "title": "Web Url"
+              "title": "Web Url",
+              "default": "https://www.usecortex.ai/"
             },
             "description": "The URL of the webpage to scrape and index"
           },
@@ -2749,7 +2819,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
           },
@@ -2760,7 +2831,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
@@ -2772,7 +2843,7 @@
             "schema": {
               "type": "string",
               "description": "Optional custom file ID for the scraped content. If not provided, a unique ID will be generated",
-              "default": "",
+              "default": "CortexDoc1234",
               "title": "File Id"
             },
             "description": "Optional custom file ID for the scraped content. If not provided, a unique ID will be generated"
@@ -2888,7 +2959,8 @@
             "schema": {
               "type": "string",
               "description": "The URL of the webpage to re-scrape",
-              "title": "Web Url"
+              "title": "Web Url",
+              "default": "https://www.usecortex.ai/"
             },
             "description": "The URL of the webpage to re-scrape"
           },
@@ -2899,7 +2971,8 @@
             "schema": {
               "type": "string",
               "description": "The file ID of the existing web scraping job to update",
-              "title": "Source Id"
+              "title": "Source Id",
+              "default": "CortexDoc1234"
             },
             "description": "The file ID of the existing web scraping job to update"
           },
@@ -2910,7 +2983,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
           },
@@ -2921,7 +2995,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
@@ -3263,7 +3337,8 @@
             "schema": {
               "type": "string",
               "description": "The file ID to check processing status for",
-              "title": "File Id"
+              "title": "File Id",
+              "default": "CortexDoc1234"
             },
             "description": "The file ID to check processing status for"
           },
@@ -3274,7 +3349,7 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "default": "",
+              "default": "tenant_1234",
               "title": "Tenant Id"
             },
             "description": "Unique identifier for the tenant/organization"
@@ -4071,7 +4146,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
           }
@@ -4193,7 +4269,7 @@
                 }
               ],
               "description": "Unique identifier for the tenant/organization",
-              "default": "",
+              "default": "tenant_1234",
               "title": "Tenant Id"
             },
             "description": "Unique identifier for the tenant/organization"
@@ -4318,7 +4394,8 @@
             "schema": {
               "type": "string",
               "description": "Unique identifier for the tenant/organization",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             },
             "description": "Unique identifier for the tenant/organization"
           },
@@ -4329,7 +4406,7 @@
             "schema": {
               "type": "string",
               "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id",
-              "default": "",
+              "default": "sub_tenant_4567",
               "title": "Sub Tenant Id"
             },
             "description": "Optional sub-tenant identifier for organizing data within a tenant. If not provided, defaults to tenant_id"
@@ -4444,7 +4521,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             }
           }
         ],
@@ -4557,7 +4635,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Tenant Id"
+              "title": "Tenant Id",
+              "default": "tenant_1234"
             }
           },
           {
@@ -4566,7 +4645,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Sub Tenant Id"
+              "title": "Sub Tenant Id",
+              "default": "sub_tenant_4567"
             }
           }
         ],
@@ -4870,7 +4950,7 @@
               }
             ],
             "title": "Tenant Metadata",
-            "description": "JSON string containing tenant-level document metadata (e.g., department, compliance_tag)\n\nExample: \u003E \"{\"department\":\"Finance\",\"compliance_tag\":\"GDPR\"}\"\n\n"
+            "description": "JSON string containing tenant-level document metadata (e.g., department, compliance_tag)\n\nExample: > \"{\"department\":\"Finance\",\"compliance_tag\":\"GDPR\"}\"\n\n"
           },
           "document_metadata": {
             "anyOf": [
@@ -4882,7 +4962,7 @@
               }
             ],
             "title": "Document Metadata",
-            "description": "JSON string containing document-specific metadata (e.g., title, author, file_id). If file_id is not provided, the system will generate an ID automatically.\n\nExample: \u003E \"{\"title\":\"Q1 Report.pdf\",\"author\":\"Alice Smith\",\"file_id\":\"custom_file_123\"}\"\n\n\n"
+            "description": "JSON string containing document-specific metadata (e.g., title, author, file_id). If file_id is not provided, the system will generate an ID automatically.\n\nExample: > \"{\"title\":\"Q1 Report.pdf\",\"author\":\"Alice Smith\",\"file_id\":\"custom_file_123\"}\"\n\n\n"
           }
         },
         "type": "object",
@@ -4912,7 +4992,7 @@
               }
             ],
             "title": "Tenant Metadata",
-            "description": "JSON string containing tenant-level document metadata (e.g., department, compliance_tag)\n\nExample: \u003E \"{\"department\":\"Finance\",\"compliance_tag\":\"GDPR\"}\"\n\n"
+            "description": "JSON string containing tenant-level document metadata (e.g., department, compliance_tag)\n\nExample: > \"{\"department\":\"Finance\",\"compliance_tag\":\"GDPR\"}\"\n\n"
           },
           "document_metadata": {
             "anyOf": [
@@ -4924,7 +5004,7 @@
               }
             ],
             "title": "Document Metadata",
-            "description": "JSON string containing document-specific metadata (e.g., title, author, file_id). If file_id is not provided, the system will generate an ID automatically.\n\nExample: \u003E \"{\"title\":\"Q1 Report.pdf\",\"author\":\"Alice Smith\",\"file_id\":\"custom_file_123\"}\"\n\n\n"
+            "description": "JSON string containing document-specific metadata (e.g., title, author, file_id). If file_id is not provided, the system will generate an ID automatically.\n\nExample: > \"{\"title\":\"Q1 Report.pdf\",\"author\":\"Alice Smith\",\"file_id\":\"custom_file_123\"}\"\n\n\n"
           }
         },
         "type": "object",
@@ -4972,7 +5052,7 @@
               }
             ],
             "title": "Tenant Metadata",
-            "description": "JSON string containing tenant-level document metadata (e.g., department, compliance_tag)\n\nExample: \u003E \"{\"department\":\"Finance\",\"compliance_tag\":\"GDPR\"}\"\n\n"
+            "description": "JSON string containing tenant-level document metadata (e.g., department, compliance_tag)\n\nExample: > \"{\"department\":\"Finance\",\"compliance_tag\":\"GDPR\"}\"\n\n"
           },
           "document_metadata": {
             "anyOf": [
@@ -4984,7 +5064,7 @@
               }
             ],
             "title": "Document Metadata",
-            "description": "JSON string containing document-specific metadata (e.g., title, author, file_id). If file_id is not provided, the system will generate an ID automatically.\n\nExample: \u003E \"{\"title\":\"Q1 Report.pdf\",\"author\":\"Alice Smith\",\"file_id\":\"custom_file_123\"}\"\n\n\n"
+            "description": "JSON string containing document-specific metadata (e.g., title, author, file_id). If file_id is not provided, the system will generate an ID automatically.\n\nExample: > \"{\"title\":\"Q1 Report.pdf\",\"author\":\"Alice Smith\",\"file_id\":\"custom_file_123\"}\"\n\n\n"
           }
         },
         "type": "object",
@@ -5011,7 +5091,7 @@
               }
             ],
             "title": "Tenant Metadata",
-            "description": "JSON string containing tenant-level document metadata (e.g., department, compliance_tag)\n\nExample: \u003E \"{\"department\":\"Finance\",\"compliance_tag\":\"GDPR\"}\"\n\n"
+            "description": "JSON string containing tenant-level document metadata (e.g., department, compliance_tag)\n\nExample: > \"{\"department\":\"Finance\",\"compliance_tag\":\"GDPR\"}\"\n\n"
           },
           "document_metadata": {
             "anyOf": [
@@ -5023,7 +5103,7 @@
               }
             ],
             "title": "Document Metadata",
-            "description": "JSON string containing document-specific metadata (e.g., title, author, file_id). If file_id is not provided, the system will generate an ID automatically.\n\nExample: \u003E \"{\"title\":\"Q1 Report.pdf\",\"author\":\"Alice Smith\",\"file_id\":\"custom_file_123\"}\"\n\n\n"
+            "description": "JSON string containing document-specific metadata (e.g., title, author, file_id). If file_id is not provided, the system will generate an ID automatically.\n\nExample: > \"{\"title\":\"Q1 Report.pdf\",\"author\":\"Alice Smith\",\"file_id\":\"custom_file_123\"}\"\n\n\n"
           }
         },
         "type": "object",
@@ -5796,7 +5876,7 @@
               }
             ],
             "title": "Tenant Metadata",
-            "description": "JSON string containing tenant-level document metadata (e.g., department, compliance_tag)\n\nExample: \u003E \"{\"department\":\"Finance\",\"compliance_tag\":\"GDPR\"}\"\n\n"
+            "description": "JSON string containing tenant-level document metadata (e.g., department, compliance_tag)\n\nExample: > \"{\"department\":\"Finance\",\"compliance_tag\":\"GDPR\"}\"\n\n"
           },
           "document_metadata": {
             "anyOf": [
@@ -5809,7 +5889,7 @@
               }
             ],
             "title": "Document Metadata",
-            "description": "JSON string containing document-specific metadata (e.g., title, author, file_id). If file_id is not provided, the system will generate an ID automatically.\n\nExample: \u003E \"{\"title\":\"Q1 Report.pdf\",\"author\":\"Alice Smith\",\"file_id\":\"custom_file_123\"}\"\n\n\n"
+            "description": "JSON string containing document-specific metadata (e.g., title, author, file_id). If file_id is not provided, the system will generate an ID automatically.\n\nExample: > \"{\"title\":\"Q1 Report.pdf\",\"author\":\"Alice Smith\",\"file_id\":\"custom_file_123\"}\"\n\n\n"
           }
         },
         "type": "object",
@@ -6447,13 +6527,13 @@
             "additionalProperties": true,
             "type": "object",
             "title": "Tenant Metadata",
-            "description": "JSON string containing tenant-level document metadata (e.g., department, compliance_tag)\n\nExample: \u003E \"{\"department\":\"Finance\",\"compliance_tag\":\"GDPR\"}\"\n\n"
+            "description": "JSON string containing tenant-level document metadata (e.g., department, compliance_tag)\n\nExample: > \"{\"department\":\"Finance\",\"compliance_tag\":\"GDPR\"}\"\n\n"
           },
           "document_metadata": {
             "additionalProperties": true,
             "type": "object",
             "title": "Document Metadata",
-            "description": "JSON string containing document-specific metadata (e.g., title, author, file_id). If file_id is not provided, the system will generate an ID automatically.\n\nExample: \u003E \"{\"title\":\"Q1 Report.pdf\",\"author\":\"Alice Smith\",\"file_id\":\"custom_file_123\"}\"\n\n\n"
+            "description": "JSON string containing document-specific metadata (e.g., title, author, file_id). If file_id is not provided, the system will generate an ID automatically.\n\nExample: > \"{\"title\":\"Q1 Report.pdf\",\"author\":\"Alice Smith\",\"file_id\":\"custom_file_123\"}\"\n\n\n"
           },
           "meta": {
             "additionalProperties": true,

--- a/docs.json
+++ b/docs.json
@@ -8,6 +8,14 @@
     "dark": "#5B21B6"
   },
   "favicon": "/favicon.svg",
+  "contextual": {
+    "options": [
+      "copy",
+      "chatgpt",
+      "claude",
+      "perplexity"
+    ]
+  },
   "navigation": {
     "tabs": [
       {
@@ -134,8 +142,7 @@
         ]
       }
     ],
-    "global": {
-    }
+    "global": {}
   },
   "logo": {
     "light": "/logo/light.svg",

--- a/fix_openapi.py
+++ b/fix_openapi.py
@@ -1,0 +1,32 @@
+import json
+
+defaults = {
+    "tenant_id": "tenant_1234",
+    "sub_tenant_id": "sub_tenant_4567",
+    "memory_id": "memory_1234",
+    "user_memory": "user_memory_1234",
+    "query": "Which mode does user prefer",
+    "user_query": "Which mode does user prefer",
+    "max_count": 5,
+    "web_url": "https://www.usecortex.ai/",
+    "file_id": "CortexDoc1234",
+    "source_id": "CortexDoc1234",
+    "user_name": "John Doe"
+}
+
+OPEN_API_PATH = "./api-reference/openapi.json"
+
+with open(OPEN_API_PATH, "r") as f:
+    openapi = json.load(f)
+
+for endpoint in openapi["paths"]:
+    for method in openapi["paths"][endpoint]:
+        if "parameters" in openapi["paths"][endpoint][method]:
+            for param in openapi["paths"][endpoint][method]["parameters"]:
+                if param["in"] == "query":
+                    param["schema"]["default"] = defaults[param["name"]]
+
+with open(OPEN_API_PATH, "w") as f:
+    json.dump(openapi, f, indent=2)
+    
+print("Updated OpenAPI file")

--- a/fix_openapi.py
+++ b/fix_openapi.py
@@ -19,14 +19,60 @@ OPEN_API_PATH = "./api-reference/openapi.json"
 with open(OPEN_API_PATH, "r") as f:
     openapi = json.load(f)
 
+print("Adding default values to query params")
 for endpoint in openapi["paths"]:
     for method in openapi["paths"][endpoint]:
         if "parameters" in openapi["paths"][endpoint][method]:
             for param in openapi["paths"][endpoint][method]["parameters"]:
                 if param["in"] == "query":
                     param["schema"]["default"] = defaults[param["name"]]
+print("Default values added to query params.")
+
+
+property_tag_to_hide = "x-cortex-docs-hide"
+
+def recursive_filter(data):
+    """
+    Recursively filters a Python object (dict or list) to remove elements
+    containing the property_tag_to_hide.
+    """
+    # If the data is a dictionary...
+    if isinstance(data, dict):
+        # Base case: If the hide tag is in the current dictionary,
+        # return None to signal its removal.
+        if property_tag_to_hide in data:
+            return None
+
+        # Recursive step: Build a new dictionary
+        new_dict = {}
+        for key, value in data.items():
+            # Recursively filter the value
+            filtered_value = recursive_filter(value)
+            # Only add the key-value pair if the value was not filtered out
+            if filtered_value is not None:
+                new_dict[key] = filtered_value
+        return new_dict
+
+    # If the data is a list...
+    elif isinstance(data, list):
+        # Recursive step: Build a new list
+        new_list = []
+        for item in data:
+            # Recursively filter the item
+            filtered_item = recursive_filter(item)
+            # Only add the item if it was not filtered out
+            if filtered_item is not None:
+                new_list.append(filtered_item)
+        return new_list
+
+    # If the data is any other type (string, int, etc.), return it as is.
+    else:
+        return data
+
+# Process the original openapi spec
+final_open_api_spec = recursive_filter(openapi)
 
 with open(OPEN_API_PATH, "w") as f:
-    json.dump(openapi, f, indent=2)
+    json.dump(final_open_api_spec, f, indent=2)
     
 print("Updated OpenAPI file")


### PR DESCRIPTION
Script does the following:
1. Adds default values to query params
2. Removes props that have `x-cortex-docs-hide` in them
3. Updates openapi spec
4. Includes a copy page modal that allows page to be copied in md, or directly moved to chatgpt and all